### PR TITLE
Use Python 3.9, new workers, and Bullseye dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+unit-tests.xml
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -53,5 +53,5 @@ print(status.paused_reason)
 ```
 apt-get install libpq-dev python3-dev libffi-dev libyaml-dev
 pip install tox
-tox --recreate -e py37
+tox --recreate -e py39
 ```

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends:
     python3-all,
     python3-setuptools
 Standards-Version: 3.9.6
-X-Python3-Version: >= 3.7
+X-Python3-Version: >= 3.9
 
 Package: wazo-agentd-client-python3
 Architecture: all

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip
-requests==2.21.0
-stevedore==1.29.0
+requests==2.25.1
+stevedore==3.2.2

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, linters
-skipsdist=True
+envlist = py39, linters
+skipsdist = True
 
 [testenv]
 commands =
@@ -22,7 +22,7 @@ commands = black --skip-string-normalization .
 
 [testenv:linters]
 skip_install = true
-basepython = python3.7
+basepython = python3.10
 deps =
     flake8
     flake8-colors

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -1,5 +1,5 @@
 - project:
     templates:
-      - wazo-tox-linters
-      - wazo-tox-py37
-      - debian-packaging-template
+      - wazo-tox-linters-310
+      - wazo-tox-py39
+      - debian-packaging-bullseye


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/wazo-lib-rest-client/pull/14