### PR TITLE
[WP-2036] Add endpoint to login

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ c = Client('agentd.example.com')
 c.agents.add_agent_to_queue(agent_id=12, queue_id=13)
 c.agents.remove_agent_from_queue(agent_id=12, queue_id=13)
 
-c.agents.login_agent(agent_id=12, extension='5678', context='internal')
+c.agents.login_agent(agent_id=12, extension='5678', context='internal', endpoint='SIP/endpoint-name')
 c.agents.logoff_agent(agent_id=12)
 
-c.agents.login_agent_by_number(agent_number='1234', extension='5678', context='internal')
+c.agents.login_agent_by_number(agent_number='1234', extension='5678', context='internal', endpoint='SIP/endpoint-name')
 c.agents.logoff_agent_by_number(agent_number='1234')
 
 c.agents.logoff_all_agents()

--- a/wazo_agentd_client/commands/agents.py
+++ b/wazo_agentd_client/commands/agents.py
@@ -31,17 +31,21 @@ class AgentsCommand(RESTCommand):
         )
         self._execute(req, self._resp_processor.generic)
 
-    def login_agent(self, agent_id, extension, context, tenant_uuid=None):
+    def login_agent(
+        self, agent_id, extension, context, endpoint=None, tenant_uuid=None
+    ):
         tenant_uuid = tenant_uuid or self._client.tenant_uuid
         req = self._req_factory.login_by_id(
-            agent_id, extension, context, tenant_uuid=tenant_uuid
+            agent_id, extension, context, endpoint=endpoint, tenant_uuid=tenant_uuid
         )
         self._execute(req, self._resp_processor.generic)
 
-    def login_agent_by_number(self, agent_number, extension, context, tenant_uuid=None):
+    def login_agent_by_number(
+        self, agent_number, extension, context, endpoint=None, tenant_uuid=None
+    ):
         tenant_uuid = tenant_uuid or self._client.tenant_uuid
         req = self._req_factory.login_by_number(
-            agent_number, extension, context, tenant_uuid=tenant_uuid
+            agent_number, extension, context, endpoint=endpoint, tenant_uuid=tenant_uuid
         )
         self._execute(req, self._resp_processor.generic)
 
@@ -152,19 +156,30 @@ class _RequestFactory:
             additional_headers['Wazo-Tenant'] = tenant_uuid
         return self._new_post_request(url, obj, additional_headers=additional_headers)
 
-    def login_by_id(self, agent_id, extension, context, tenant_uuid=None):
+    def login_by_id(
+        self, agent_id, extension, context, endpoint=None, tenant_uuid=None
+    ):
         return self._login(
-            'by-id', agent_id, extension, context, tenant_uuid=tenant_uuid
+            'by-id', agent_id, extension, context, endpoint, tenant_uuid=tenant_uuid
         )
 
-    def login_by_number(self, agent_number, extension, context, tenant_uuid=None):
+    def login_by_number(
+        self, agent_number, extension, context, endpoint=None, tenant_uuid=None
+    ):
         return self._login(
-            'by-number', agent_number, extension, context, tenant_uuid=tenant_uuid
+            'by-number',
+            agent_number,
+            extension,
+            context,
+            endpoint,
+            tenant_uuid=tenant_uuid,
         )
 
-    def _login(self, by, value, extension, context, tenant_uuid=None):
+    def _login(self, by, value, extension, context, endpoint=None, tenant_uuid=None):
         url = f'{self._base_url}/{by}/{value}/login'
         obj = {'extension': extension, 'context': context}
+        if endpoint:
+            obj['endpoint'] = endpoint
         additional_headers = {}
         if tenant_uuid:
             additional_headers['Wazo-Tenant'] = tenant_uuid

--- a/wazo_agentd_client/commands/tests/test_agents.py
+++ b/wazo_agentd_client/commands/tests/test_agents.py
@@ -25,6 +25,7 @@ class TestRequestFactory(unittest.TestCase):
         self.agent_number = '1002'
         self.extension = '1222'
         self.context = 'alice'
+        self.endpoint = 'SIP/alice'
         self.queue_id = 3
         self.line_id = 4
 
@@ -46,18 +47,28 @@ class TestRequestFactory(unittest.TestCase):
 
     def test_login_by_id(self):
         expected_url = f'{self.base_url}/by-id/2/login'
-        expected_body = {'extension': self.extension, 'context': self.context}
+        expected_body = {
+            'extension': self.extension,
+            'context': self.context,
+            'endpoint': self.endpoint,
+        }
 
-        req = self.req_factory.login_by_id(self.agent_id, self.extension, self.context)
+        req = self.req_factory.login_by_id(
+            self.agent_id, self.extension, self.context, self.endpoint
+        )
 
         self._assert_post_request(req, expected_url, expected_body)
 
     def test_login_by_number(self):
         expected_url = f'{self.base_url}/by-number/1002/login'
-        expected_body = {'extension': self.extension, 'context': self.context}
+        expected_body = {
+            'extension': self.extension,
+            'context': self.context,
+            'endpoint': self.endpoint,
+        }
 
         req = self.req_factory.login_by_number(
-            self.agent_number, self.extension, self.context
+            self.agent_number, self.extension, self.context, self.endpoint
         )
 
         self._assert_post_request(req, expected_url, expected_body)

--- a/wazo_agentd_client/commands/tests/test_agents.py
+++ b/wazo_agentd_client/commands/tests/test_agents.py
@@ -25,7 +25,7 @@ class TestRequestFactory(unittest.TestCase):
         self.agent_number = '1002'
         self.extension = '1222'
         self.context = 'alice'
-        self.endpoint = 'SIP/alice'
+        self.endpoint = 'PJSIP/alice'
         self.queue_id = 3
         self.line_id = 4
 
@@ -232,7 +232,7 @@ class TestResponseProcessor(unittest.TestCase):
             'paused': True,
             'extension': '1222',
             'context': 'alice',
-            'state_interface': 'SIP/alice',
+            'state_interface': 'PJSIP/alice',
             'tenant_uuid': FAKE_TENANT,
         }
         resp = new_response(200, v)
@@ -258,7 +258,7 @@ class TestResponseProcessor(unittest.TestCase):
             'paused': False,
             'extension': '1222',
             'context': 'alice',
-            'state_interface': 'SIP/alice',
+            'state_interface': 'PJSIP/alice',
             'tenant_uuid': FAKE_TENANT,
         }
         resp = new_response(200, [v])


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an optional `endpoint` parameter to agent login methods and propagates it in requests; updates tests and README, and switches state_interface examples to PJSIP.
> 
> - **Agents API**:
>   - `AgentsCommand.login_agent` and `login_agent_by_number` now accept optional `endpoint` and pass it through.
>   - `_RequestFactory.login_by_id`, `login_by_number`, and `_login` include `endpoint` in the POST body when provided.
> - **Tests**:
>   - Update login tests to expect `endpoint` in request bodies.
>   - Change `state_interface` expectations from `SIP/...` to `PJSIP/...`.
> - **Docs**:
>   - README usage shows new `endpoint` argument for login methods.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72149fa60123b198057bc7b87cd80a6eac4d22d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->