### PR TITLE
WP-2110: add user agent subscribe/unsubscribe to/from queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ c.agents.unpause_user_agent()
 c.agents.logoff_user_agent()
 c.agents.get_user_agent_status()
 
+c.agents.user_agent_login_to_queue(queue_id=13)
+c.agents.user_agent_logoff_from_queue(queue_id=13)
+
 status = c.agents.get_agent_status(agent_id=12)
 status = c.agents.get_agent_status_by_number(agent_number='1234')
 status = c.agents.get_agent_statuses()

--- a/wazo_agentd_client/commands/agents.py
+++ b/wazo_agentd_client/commands/agents.py
@@ -121,6 +121,18 @@ class AgentsCommand(RESTCommand):
         req = self._req_factory.status_all(tenant_uuid=tenant_uuid, recurse=recurse)
         return self._execute(req, self._resp_processor.status_all)
 
+    def subscribe_user_agent_to_queue(self, queue_id, tenant_uuid=None):
+        tenant_uuid = tenant_uuid or self._client.tenant_uuid
+        user_req_factory = _RequestFactory(self._client.url())
+        req = user_req_factory.subscribe_user_agent_to_queue(queue_id, tenant_uuid=tenant_uuid)
+        return self._execute(req, self._resp_processor.generic)
+
+    def unsubscribe_user_agent_from_queue(self, queue_id, tenant_uuid=None):
+        tenant_uuid = tenant_uuid or self._client.tenant_uuid
+        user_req_factory = _RequestFactory(self._client.url())
+        req = user_req_factory.unsubscribe_user_agent_from_queue(queue_id, tenant_uuid=tenant_uuid)
+        return self._execute(req, self._resp_processor.generic)
+
     def _execute(self, req, processor_fun, timeout=None):
         timeout = timeout if timeout is not None else self.timeout
         resp = self.session.send(self.session.prepare_request(req), timeout=timeout)
@@ -313,6 +325,20 @@ class _RequestFactory:
             url, additional_headers=additional_headers, params=params
         )
 
+    def subscribe_user_agent_to_queue(self, queue_id, tenant_uuid=None):
+        url = f'{self._base_url}/users/me/agents/queues/{queue_id}/subscribe'
+        additional_headers = {}
+        if tenant_uuid:
+            additional_headers['Wazo-Tenant'] = tenant_uuid
+        return self._new_put_request(url, additional_headers=additional_headers)
+
+    def unsubscribe_user_agent_from_queue(self, queue_id, tenant_uuid=None):
+        url = f'{self._base_url}/users/me/agents/queues/{queue_id}/unsubscribe'
+        additional_headers = {}
+        if tenant_uuid:
+            additional_headers['Wazo-Tenant'] = tenant_uuid
+        return self._new_put_request(url, additional_headers=additional_headers)
+
     def _new_get_request(self, url, additional_headers=None, params=None):
         headers = dict(self._headers)
         if additional_headers:
@@ -329,3 +355,14 @@ class _RequestFactory:
             data = json.dumps(obj)
             headers['Content-Type'] = 'application/json'
         return requests.Request('POST', url, headers, data=data, params=params)
+
+    def _new_put_request(self, url, obj=None, additional_headers=None, params=None):
+        headers = dict(self._headers)
+        if additional_headers:
+            headers.update(additional_headers)
+        if obj is None:
+            data = None
+        else:
+            data = json.dumps(obj)
+            headers['Content-Type'] = 'application/json'
+        return requests.Request('PUT', url, headers, data=data, params=params)

--- a/wazo_agentd_client/commands/agents.py
+++ b/wazo_agentd_client/commands/agents.py
@@ -121,18 +121,18 @@ class AgentsCommand(RESTCommand):
         req = self._req_factory.status_all(tenant_uuid=tenant_uuid, recurse=recurse)
         return self._execute(req, self._resp_processor.status_all)
 
-    def subscribe_user_agent_to_queue(self, queue_id, tenant_uuid=None):
+    def user_agent_login_to_queue(self, queue_id, tenant_uuid=None):
         tenant_uuid = tenant_uuid or self._client.tenant_uuid
         user_req_factory = _RequestFactory(self._client.url())
-        req = user_req_factory.subscribe_user_agent_to_queue(
+        req = user_req_factory.user_agent_login_to_queue(
             queue_id, tenant_uuid=tenant_uuid
         )
         return self._execute(req, self._resp_processor.generic)
 
-    def unsubscribe_user_agent_from_queue(self, queue_id, tenant_uuid=None):
+    def user_agent_logoff_from_queue(self, queue_id, tenant_uuid=None):
         tenant_uuid = tenant_uuid or self._client.tenant_uuid
         user_req_factory = _RequestFactory(self._client.url())
-        req = user_req_factory.unsubscribe_user_agent_from_queue(
+        req = user_req_factory.user_agent_logoff_from_queue(
             queue_id, tenant_uuid=tenant_uuid
         )
         return self._execute(req, self._resp_processor.generic)
@@ -329,15 +329,15 @@ class _RequestFactory:
             url, additional_headers=additional_headers, params=params
         )
 
-    def subscribe_user_agent_to_queue(self, queue_id, tenant_uuid=None):
-        url = f'{self._base_url}/users/me/agents/queues/{queue_id}/subscribe'
+    def user_agent_login_to_queue(self, queue_id, tenant_uuid=None):
+        url = f'{self._base_url}/users/me/agents/queues/{queue_id}/login'
         additional_headers = {}
         if tenant_uuid:
             additional_headers['Wazo-Tenant'] = tenant_uuid
         return self._new_put_request(url, additional_headers=additional_headers)
 
-    def unsubscribe_user_agent_from_queue(self, queue_id, tenant_uuid=None):
-        url = f'{self._base_url}/users/me/agents/queues/{queue_id}/unsubscribe'
+    def user_agent_logoff_from_queue(self, queue_id, tenant_uuid=None):
+        url = f'{self._base_url}/users/me/agents/queues/{queue_id}/logoff'
         additional_headers = {}
         if tenant_uuid:
             additional_headers['Wazo-Tenant'] = tenant_uuid

--- a/wazo_agentd_client/commands/agents.py
+++ b/wazo_agentd_client/commands/agents.py
@@ -124,13 +124,17 @@ class AgentsCommand(RESTCommand):
     def subscribe_user_agent_to_queue(self, queue_id, tenant_uuid=None):
         tenant_uuid = tenant_uuid or self._client.tenant_uuid
         user_req_factory = _RequestFactory(self._client.url())
-        req = user_req_factory.subscribe_user_agent_to_queue(queue_id, tenant_uuid=tenant_uuid)
+        req = user_req_factory.subscribe_user_agent_to_queue(
+            queue_id, tenant_uuid=tenant_uuid
+        )
         return self._execute(req, self._resp_processor.generic)
 
     def unsubscribe_user_agent_from_queue(self, queue_id, tenant_uuid=None):
         tenant_uuid = tenant_uuid or self._client.tenant_uuid
         user_req_factory = _RequestFactory(self._client.url())
-        req = user_req_factory.unsubscribe_user_agent_from_queue(queue_id, tenant_uuid=tenant_uuid)
+        req = user_req_factory.unsubscribe_user_agent_from_queue(
+            queue_id, tenant_uuid=tenant_uuid
+        )
         return self._execute(req, self._resp_processor.generic)
 
     def _execute(self, req, processor_fun, timeout=None):

--- a/wazo_agentd_client/commands/tests/test_agents.py
+++ b/wazo_agentd_client/commands/tests/test_agents.py
@@ -179,6 +179,20 @@ class TestRequestFactory(unittest.TestCase):
 
         self._assert_get_request(req, expected_url)
 
+    def test_user_agent_login_to_queue(self):
+        expected_url = f'{self.base_url}/users/me/agents/queues/1/login'
+
+        req = self.req_factory.user_agent_login_to_queue(1)
+
+        self._assert_put_request(req, expected_url)
+
+    def test_user_agent_logoff_to_queue(self):
+        expected_url = f'{self.base_url}/users/me/agents/queues/1/logoff'
+
+        req = self.req_factory.user_agent_logoff_from_queue(1)
+
+        self._assert_put_request(req, expected_url)
+
     def _assert_get_request(self, req, expected_url):
         prep_req = req.prepare()
         assert_that(prep_req.method, equal_to('GET'))
@@ -187,6 +201,15 @@ class TestRequestFactory(unittest.TestCase):
     def _assert_post_request(self, req, expected_url, expected_body=None):
         prep_req = req.prepare()
         assert_that(prep_req.method, equal_to('POST'))
+        assert_that(prep_req.url, equal_to(expected_url))
+        if expected_body is None:
+            assert_that(prep_req.body, equal_to(None))
+        else:
+            assert_that(json.loads(prep_req.body), equal_to(expected_body))
+
+    def _assert_put_request(self, req, expected_url, expected_body=None):
+        prep_req = req.prepare()
+        assert_that(prep_req.method, equal_to('PUT'))
         assert_that(prep_req.url, equal_to(expected_url))
         if expected_body is None:
             assert_that(prep_req.body, equal_to(None))

--- a/wazo_agentd_client/commands/tests/test_agents.py
+++ b/wazo_agentd_client/commands/tests/test_agents.py
@@ -186,7 +186,7 @@ class TestRequestFactory(unittest.TestCase):
 
         self._assert_put_request(req, expected_url)
 
-    def test_user_agent_logoff_to_queue(self):
+    def test_user_agent_logoff_from_queue(self):
         expected_url = f'{self.base_url}/users/me/agents/queues/1/logoff'
 
         req = self.req_factory.user_agent_logoff_from_queue(1)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds client methods for user agents to login to or logoff from a specific queue, with PUT requests, tests, and README examples.
> 
> - **Agents client**:
>   - Add `AgentsCommand.user_agent_login_to_queue(queue_id, tenant_uuid=None)` and `user_agent_logoff_from_queue(queue_id, tenant_uuid=None)`.
>   - Extend `_RequestFactory` with `user_agent_login_to_queue` and `user_agent_logoff_from_queue` using PUT to `users/me/agents/queues/{queue_id}/login|logoff`.
>   - Introduce `_new_put_request` helper; propagate optional `Wazo-Tenant` header.
> - **Tests**:
>   - Add PUT request tests for the new queue login/logoff endpoints.
> - **Docs**:
>   - Update `README.md` usage to include the new user-agent queue login/logoff calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b16fb6602369c4bc5206fc399587ff5511c1713f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->