### PR TITLE
TASK-250-admin-queue-login-v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ c.agents.get_user_agent_status()
 c.agents.user_agent_login_to_queue(queue_id=13)
 c.agents.user_agent_logoff_from_queue(queue_id=13)
 
+# Admin: per-queue login/logoff by agent ID
+c.agents.user_agent_login_to_queue(queue_id=13, agent_id=12)
+c.agents.user_agent_logoff_from_queue(queue_id=13, agent_id=12)
+
 status = c.agents.get_agent_status(agent_id=12)
 status = c.agents.get_agent_status_by_number(agent_number='1234')
 status = c.agents.get_agent_statuses()
@@ -50,10 +54,9 @@ print(status.paused)
 print(status.paused_reason)
 ```
 
-
 ## Running unit tests
 
-```
+```shell
 apt-get install libpq-dev python3-dev libffi-dev libyaml-dev
 pip install tox
 tox --recreate -e py311

--- a/README.md
+++ b/README.md
@@ -35,9 +35,8 @@ c.agents.get_user_agent_status()
 c.agents.user_agent_login_to_queue(queue_id=13)
 c.agents.user_agent_logoff_from_queue(queue_id=13)
 
-# Admin: per-queue login/logoff by agent ID
-c.agents.user_agent_login_to_queue(queue_id=13, agent_id=12)
-c.agents.user_agent_logoff_from_queue(queue_id=13, agent_id=12)
+c.agents.agent_login_to_queue(queue_id=13, agent_id=12)
+c.agents.agent_logoff_from_queue(queue_id=13, agent_id=12)
 
 status = c.agents.get_agent_status(agent_id=12)
 status = c.agents.get_agent_status_by_number(agent_number='1234')

--- a/wazo_agentd_client/commands/agents.py
+++ b/wazo_agentd_client/commands/agents.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -121,20 +121,30 @@ class AgentsCommand(RESTCommand):
         req = self._req_factory.status_all(tenant_uuid=tenant_uuid, recurse=recurse)
         return self._execute(req, self._resp_processor.status_all)
 
-    def user_agent_login_to_queue(self, queue_id, tenant_uuid=None):
+    def user_agent_login_to_queue(self, queue_id, agent_id=None, tenant_uuid=None):
         tenant_uuid = tenant_uuid or self._client.tenant_uuid
-        user_req_factory = _RequestFactory(self._client.url())
-        req = user_req_factory.user_agent_login_to_queue(
-            queue_id, tenant_uuid=tenant_uuid
-        )
+        if agent_id:
+            req = self._req_factory.agent_queue_login(
+                agent_id, queue_id, tenant_uuid=tenant_uuid
+            )
+        else:
+            user_req_factory = _RequestFactory(self._client.url())
+            req = user_req_factory.user_agent_login_to_queue(
+                queue_id, tenant_uuid=tenant_uuid
+            )
         return self._execute(req, self._resp_processor.generic)
 
-    def user_agent_logoff_from_queue(self, queue_id, tenant_uuid=None):
+    def user_agent_logoff_from_queue(self, queue_id, agent_id=None, tenant_uuid=None):
         tenant_uuid = tenant_uuid or self._client.tenant_uuid
-        user_req_factory = _RequestFactory(self._client.url())
-        req = user_req_factory.user_agent_logoff_from_queue(
-            queue_id, tenant_uuid=tenant_uuid
-        )
+        if agent_id:
+            req = self._req_factory.agent_queue_logoff(
+                agent_id, queue_id, tenant_uuid=tenant_uuid
+            )
+        else:
+            user_req_factory = _RequestFactory(self._client.url())
+            req = user_req_factory.user_agent_logoff_from_queue(
+                queue_id, tenant_uuid=tenant_uuid
+            )
         return self._execute(req, self._resp_processor.generic)
 
     def _execute(self, req, processor_fun, timeout=None):
@@ -329,8 +339,22 @@ class _RequestFactory:
             url, additional_headers=additional_headers, params=params
         )
 
+    def agent_queue_login(self, agent_id, queue_id, tenant_uuid=None):
+        url = f'{self._base_url}/{agent_id}/queues/{queue_id}/login'
+        additional_headers = {}
+        if tenant_uuid:
+            additional_headers['Wazo-Tenant'] = tenant_uuid
+        return self._new_put_request(url, additional_headers=additional_headers)
+
     def user_agent_login_to_queue(self, queue_id, tenant_uuid=None):
         url = f'{self._base_url}/users/me/agents/queues/{queue_id}/login'
+        additional_headers = {}
+        if tenant_uuid:
+            additional_headers['Wazo-Tenant'] = tenant_uuid
+        return self._new_put_request(url, additional_headers=additional_headers)
+
+    def agent_queue_logoff(self, agent_id, queue_id, tenant_uuid=None):
+        url = f'{self._base_url}/{agent_id}/queues/{queue_id}/logoff'
         additional_headers = {}
         if tenant_uuid:
             additional_headers['Wazo-Tenant'] = tenant_uuid

--- a/wazo_agentd_client/commands/agents.py
+++ b/wazo_agentd_client/commands/agents.py
@@ -121,30 +121,34 @@ class AgentsCommand(RESTCommand):
         req = self._req_factory.status_all(tenant_uuid=tenant_uuid, recurse=recurse)
         return self._execute(req, self._resp_processor.status_all)
 
-    def user_agent_login_to_queue(self, queue_id, agent_id=None, tenant_uuid=None):
+    def agent_login_to_queue(self, agent_id, queue_id, tenant_uuid=None):
         tenant_uuid = tenant_uuid or self._client.tenant_uuid
-        if agent_id:
-            req = self._req_factory.agent_queue_login(
-                agent_id, queue_id, tenant_uuid=tenant_uuid
-            )
-        else:
-            user_req_factory = _RequestFactory(self._client.url())
-            req = user_req_factory.user_agent_login_to_queue(
-                queue_id, tenant_uuid=tenant_uuid
-            )
+        req = self._req_factory.agent_login_to_queue(
+            agent_id, queue_id, tenant_uuid=tenant_uuid
+        )
         return self._execute(req, self._resp_processor.generic)
 
-    def user_agent_logoff_from_queue(self, queue_id, agent_id=None, tenant_uuid=None):
+    def user_agent_login_to_queue(self, queue_id, tenant_uuid=None):
         tenant_uuid = tenant_uuid or self._client.tenant_uuid
-        if agent_id:
-            req = self._req_factory.agent_queue_logoff(
-                agent_id, queue_id, tenant_uuid=tenant_uuid
-            )
-        else:
-            user_req_factory = _RequestFactory(self._client.url())
-            req = user_req_factory.user_agent_logoff_from_queue(
-                queue_id, tenant_uuid=tenant_uuid
-            )
+        user_req_factory = _RequestFactory(self._client.url())
+        req = user_req_factory.user_agent_login_to_queue(
+            queue_id, tenant_uuid=tenant_uuid
+        )
+        return self._execute(req, self._resp_processor.generic)
+
+    def agent_logoff_from_queue(self, agent_id, queue_id, tenant_uuid=None):
+        tenant_uuid = tenant_uuid or self._client.tenant_uuid
+        req = self._req_factory.agent_logoff_from_queue(
+            agent_id, queue_id, tenant_uuid=tenant_uuid
+        )
+        return self._execute(req, self._resp_processor.generic)
+
+    def user_agent_logoff_from_queue(self, queue_id, tenant_uuid=None):
+        tenant_uuid = tenant_uuid or self._client.tenant_uuid
+        user_req_factory = _RequestFactory(self._client.url())
+        req = user_req_factory.user_agent_logoff_from_queue(
+            queue_id, tenant_uuid=tenant_uuid
+        )
         return self._execute(req, self._resp_processor.generic)
 
     def _execute(self, req, processor_fun, timeout=None):
@@ -339,7 +343,7 @@ class _RequestFactory:
             url, additional_headers=additional_headers, params=params
         )
 
-    def agent_queue_login(self, agent_id, queue_id, tenant_uuid=None):
+    def agent_login_to_queue(self, agent_id, queue_id, tenant_uuid=None):
         url = f'{self._base_url}/{agent_id}/queues/{queue_id}/login'
         additional_headers = {}
         if tenant_uuid:
@@ -353,7 +357,7 @@ class _RequestFactory:
             additional_headers['Wazo-Tenant'] = tenant_uuid
         return self._new_put_request(url, additional_headers=additional_headers)
 
-    def agent_queue_logoff(self, agent_id, queue_id, tenant_uuid=None):
+    def agent_logoff_from_queue(self, agent_id, queue_id, tenant_uuid=None):
         url = f'{self._base_url}/{agent_id}/queues/{queue_id}/logoff'
         additional_headers = {}
         if tenant_uuid:

--- a/wazo_agentd_client/commands/tests/test_agents.py
+++ b/wazo_agentd_client/commands/tests/test_agents.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import json
@@ -179,10 +179,24 @@ class TestRequestFactory(unittest.TestCase):
 
         self._assert_get_request(req, expected_url)
 
+    def test_agent_queue_login(self):
+        expected_url = f'{self.base_url}/2/queues/1/login'
+
+        req = self.req_factory.agent_queue_login(self.agent_id, 1)
+
+        self._assert_put_request(req, expected_url)
+
     def test_user_agent_login_to_queue(self):
         expected_url = f'{self.base_url}/users/me/agents/queues/1/login'
 
         req = self.req_factory.user_agent_login_to_queue(1)
+
+        self._assert_put_request(req, expected_url)
+
+    def test_agent_queue_logoff(self):
+        expected_url = f'{self.base_url}/2/queues/1/logoff'
+
+        req = self.req_factory.agent_queue_logoff(self.agent_id, 1)
 
         self._assert_put_request(req, expected_url)
 

--- a/wazo_agentd_client/commands/tests/test_agents.py
+++ b/wazo_agentd_client/commands/tests/test_agents.py
@@ -179,10 +179,10 @@ class TestRequestFactory(unittest.TestCase):
 
         self._assert_get_request(req, expected_url)
 
-    def test_agent_queue_login(self):
+    def test_agent_login_to_queue(self):
         expected_url = f'{self.base_url}/2/queues/1/login'
 
-        req = self.req_factory.agent_queue_login(self.agent_id, 1)
+        req = self.req_factory.agent_login_to_queue(self.agent_id, 1)
 
         self._assert_put_request(req, expected_url)
 
@@ -193,10 +193,10 @@ class TestRequestFactory(unittest.TestCase):
 
         self._assert_put_request(req, expected_url)
 
-    def test_agent_queue_logoff(self):
+    def test_agent_logoff_from_queue(self):
         expected_url = f'{self.base_url}/2/queues/1/logoff'
 
-        req = self.req_factory.agent_queue_logoff(self.agent_id, 1)
+        req = self.req_factory.agent_logoff_from_queue(self.agent_id, 1)
 
         self._assert_put_request(req, expected_url)
 


### PR DESCRIPTION
Why: admins need to login/logoff an agent to a specific queue by
agent ID. The new optional agent_id parameter targets
/agents/{agent_id}/queues/{queue_id}/ instead of /users/me/.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new client methods and request builders without changing existing endpoints, with unit tests covering the new URL/method behavior.
> 
> **Overview**
> Adds admin-oriented queue membership actions via new `agent_login_to_queue` and `agent_logoff_from_queue` methods that call `/agents/{agent_id}/queues/{queue_id}/login|logoff` (PUT) instead of the existing `/users/me/...` routes.
> 
> Updates unit tests to validate the new request URLs/methods, and refreshes `README.md` examples plus a small markdown code-block tweak.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa8ae5092ef734c9999df8e7628dc53240b30f7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->