### PR TITLE
[TASK-252] add all_queues param to relog command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ c.agents.logoff_agent_by_number(agent_number='1234')
 
 c.agents.logoff_all_agents()
 c.agents.relog_all_agents()
+c.agents.relog_all_agents(all_queues=True)  # also restore membership for queues the agent was logged off from
 
 c.agents.pause_agent_by_number(agent_number='1234')
 c.agents.unpause_agent_by_number(agent_number='1234')

--- a/wazo_agentd_client/commands/agents.py
+++ b/wazo_agentd_client/commands/agents.py
@@ -76,9 +76,13 @@ class AgentsCommand(RESTCommand):
         req = self._req_factory.logoff_all(tenant_uuid=tenant_uuid, recurse=recurse)
         self._execute(req, self._resp_processor.generic)
 
-    def relog_all_agents(self, tenant_uuid=None, recurse=False, timeout=None):
+    def relog_all_agents(
+        self, tenant_uuid=None, recurse=False, all_queues=False, timeout=None
+    ):
         tenant_uuid = tenant_uuid or self._client.tenant_uuid
-        req = self._req_factory.relog_all(tenant_uuid=tenant_uuid, recurse=recurse)
+        req = self._req_factory.relog_all(
+            tenant_uuid=tenant_uuid, recurse=recurse, all_queues=all_queues
+        )
         self._execute(req, self._resp_processor.generic, timeout=timeout)
 
     def pause_agent_by_number(self, agent_number, tenant_uuid=None):
@@ -319,7 +323,7 @@ class _RequestFactory:
             params['recurse'] = True
         return self._new_post_request(url)
 
-    def relog_all(self, tenant_uuid=None, recurse=False):
+    def relog_all(self, tenant_uuid=None, recurse=False, all_queues=False):
         url = f'{self._base_url}/relog'
         additional_headers = {}
         params = {}
@@ -327,6 +331,8 @@ class _RequestFactory:
             additional_headers['Wazo-Tenant'] = tenant_uuid
         if recurse:
             params['recurse'] = True
+        if all_queues:
+            params['all_queues'] = True
         return self._new_post_request(
             url, additional_headers=additional_headers, params=params
         )

--- a/wazo_agentd_client/commands/tests/test_agents.py
+++ b/wazo_agentd_client/commands/tests/test_agents.py
@@ -172,6 +172,13 @@ class TestRequestFactory(unittest.TestCase):
 
         self._assert_post_request(req, expected_url)
 
+    def test_relog_all_with_all_queues(self):
+        expected_url = f'{self.base_url}/relog?all_queues=True'
+
+        req = self.req_factory.relog_all(all_queues=True)
+
+        self._assert_post_request(req, expected_url)
+
     def test_status_all(self):
         expected_url = self.base_url
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds an optional query parameter to the `relog` request path and updates docs/tests; behavior is unchanged unless callers pass `all_queues=True`.
> 
> **Overview**
> Adds an `all_queues` flag to `AgentsCommand.relog_all_agents()` and `_RequestFactory.relog_all()` so the client can request a full relog including queue membership restoration via `POST /relog?all_queues=True`.
> 
> Updates the README usage example and extends unit tests to cover the new `all_queues` query parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adc970f0f9c9041dbb1f7fdced869f1dc6f289fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->